### PR TITLE
Fixed broken maven build after module renaming

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,8 +10,8 @@
   <name>Android-PullToRefresh Project</name>
 
   <modules>
-    <module>pulltorefresh-library</module>
-    <module>pulltorefresh-sample</module>
+    <module>library</module>
+    <module>sample</module>
   </modules>
 
   <properties>


### PR DESCRIPTION
Renamed the two sub-projects so that building the project with Maven works again
