### PR TITLE
only allow the bottom pull if the last item is fully displayed

### DIFF
--- a/library/src/com/handmark/pulltorefresh/library/PullToRefreshAdapterViewBase.java
+++ b/library/src/com/handmark/pulltorefresh/library/PullToRefreshAdapterViewBase.java
@@ -135,7 +135,7 @@ public abstract class PullToRefreshAdapterViewBase<T extends AbsListView> extend
 		if (count == 0) {
 			return true;
 		} else if (refreshableView.getLastVisiblePosition() == count - 1) {
-			return true;
+				return refreshableView.getChildAt(refreshableView.getChildCount()-1).getBottom() <= refreshableView.getBottom();
 		}
 		return false;
 	}


### PR DESCRIPTION
The widget would start the pull system when only a portion of the last element was displayed
