### PR TITLE
Disabling scrolling while refreshing has no effect on manual refresh

### DIFF
--- a/library/src/com/handmark/pulltorefresh/library/PullToRefreshBase.java
+++ b/library/src/com/handmark/pulltorefresh/library/PullToRefreshBase.java
@@ -309,7 +309,7 @@ public abstract class PullToRefreshBase<T extends View> extends LinearLayout {
 			return false;
 		}
 
-		if (state == REFRESHING && disableScrollingWhileRefreshing) {
+		if (isRefreshing() && disableScrollingWhileRefreshing) {
 			return true;
 		}
 
@@ -363,7 +363,7 @@ public abstract class PullToRefreshBase<T extends View> extends LinearLayout {
 			return false;
 		}
 
-		if (state == REFRESHING && disableScrollingWhileRefreshing) {
+		if (isRefreshing() && disableScrollingWhileRefreshing) {
 			return true;
 		}
 


### PR DESCRIPTION
I've tried to disable scrolling while refreshing (in PullToRefreshListActivity I've selected "Disable Scrolling while Refreshing" menu item) and after that I've selected "Manual Refresh" menu item.
Scrolling remains enabled while manual refresh.
