### PR TITLE
Prefix attrs w/ ptr to avoid common res conflicts

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,9 @@ It can also be styled using XML, such as in the sample ExpandableListView Sample
     android:id="@+id/pull_refresh_expandable_list"
     android:layout_height="fill_parent"
     android:layout_width="fill_parent"
-    ptr:adapterViewBackground="@android:color/white"
-    ptr:headerBackground="@android:color/darker_gray"
-    ptr:headerTextColor="@android:color/white" />
+    ptr:ptr_adapterViewBackground="@android:color/white"
+    ptr:ptr_headerBackground="@android:color/darker_gray"
+    ptr:ptr_headerTextColor="@android:color/white" />
 ```
 
 ### Activity

--- a/library/res/values/attrs.xml
+++ b/library/res/values/attrs.xml
@@ -2,9 +2,9 @@
 <resources>
 
     <declare-styleable name="PullToRefresh">
-        <attr name="adapterViewBackground" format="reference|color" />
-        <attr name="headerBackground" format="reference|color" />
-        <attr name="headerTextColor" format="color" />
+        <attr name="ptr_adapterViewBackground" format="reference|color" />
+        <attr name="ptr_headerBackground" format="reference|color" />
+        <attr name="ptr_headerTextColor" format="color" />
         <attr name="mode">
             <flag name="pullDownFromTop" value="0x1" />
             <flag name="pullUpFromBottom" value="0x2" />

--- a/library/src/com/handmark/pulltorefresh/library/PullToRefreshBase.java
+++ b/library/src/com/handmark/pulltorefresh/library/PullToRefreshBase.java
@@ -600,11 +600,11 @@ public abstract class PullToRefreshBase<T extends View> extends LinearLayout {
 		}
 
 		// Styleables from XML
-		if (a.hasValue(R.styleable.PullToRefresh_headerBackground)) {
-			setBackgroundResource(a.getResourceId(R.styleable.PullToRefresh_headerBackground, Color.WHITE));
+		if (a.hasValue(R.styleable.PullToRefresh_ptr_headerBackground)) {
+			setBackgroundResource(a.getResourceId(R.styleable.PullToRefresh_ptr_headerBackground, Color.WHITE));
 		}
-		if (a.hasValue(R.styleable.PullToRefresh_adapterViewBackground)) {
-			mRefreshableView.setBackgroundResource(a.getResourceId(R.styleable.PullToRefresh_adapterViewBackground,
+		if (a.hasValue(R.styleable.PullToRefresh_ptr_adapterViewBackground)) {
+			mRefreshableView.setBackgroundResource(a.getResourceId(R.styleable.PullToRefresh_ptr_adapterViewBackground,
 					Color.WHITE));
 		}
 		a.recycle();

--- a/library/src/com/handmark/pulltorefresh/library/internal/LoadingLayout.java
+++ b/library/src/com/handmark/pulltorefresh/library/internal/LoadingLayout.java
@@ -67,8 +67,8 @@ public class LoadingLayout extends FrameLayout {
 				break;
 		}
 
-		if (attrs.hasValue(R.styleable.PullToRefresh_headerTextColor)) {
-			final int color = attrs.getColor(R.styleable.PullToRefresh_headerTextColor, Color.BLACK);
+		if (attrs.hasValue(R.styleable.PullToRefresh_ptr_headerTextColor)) {
+			final int color = attrs.getColor(R.styleable.PullToRefresh_ptr_headerTextColor, Color.BLACK);
 			setTextColor(color);
 		}
 	}

--- a/sample/res/layout/pull_to_refresh_expandable_list.xml
+++ b/sample/res/layout/pull_to_refresh_expandable_list.xml
@@ -11,9 +11,9 @@
         android:id="@+id/pull_refresh_expandable_list"
         android:layout_height="fill_parent"
         android:layout_width="fill_parent"
-        ptr:adapterViewBackground="@android:color/white"
-        ptr:headerBackground="@android:color/darker_gray"
-        ptr:headerTextColor="@android:color/white"
+        ptr:ptr_adapterViewBackground="@android:color/white"
+        ptr:ptr_headerBackground="@android:color/darker_gray"
+        ptr:ptr_headerTextColor="@android:color/white"
         ptr:mode="pullUpFromBottom" />
 
 </LinearLayout>


### PR DESCRIPTION
When compiling a basic project with Android-PullToRefresh and another library that contains attributes such as headerBackground, you get the following error:

[aapt] ./finch/libs/JakeWharton-ActionBarSherlock-df676ad/library/res/values/abs__attrs.xml:222: error: Attribute "headerBackground" has already been defined

This is with ActionBarSherlock 4.0.  According to my research and some advice #android-dev, libraries should prefix custom attributes with a unique namespace.  ActionBarSherlock likely can't do this as it needs to replicate the android-support library as closely as possible.

These small changes mitigate any such problems at least with Android-PullToRefresh.  Have a look and see what you think :)
