### PR TITLE
PullToRefreshWebView glitch on small screen.

### DIFF
--- a/library/src/com/handmark/pulltorefresh/library/PullToRefreshWebView.java
+++ b/library/src/com/handmark/pulltorefresh/library/PullToRefreshWebView.java
@@ -72,6 +72,7 @@ public class PullToRefreshWebView extends PullToRefreshBase<WebView> {
 
 	@Override
 	protected boolean isReadyForPullUp() {
-		return mRefreshableView.getScrollY() >= (mRefreshableView.getContentHeight() - mRefreshableView.getHeight());
+		int exactContentHeight = (int) Math.floor(mRefreshableView.getContentHeight() * mRefreshableView.getScale());
+		return mRefreshableView.getScrollY() >= (exactContentHeight - mRefreshableView.getHeight());
 	}
 }


### PR DESCRIPTION
On a model with small screens, such as a smart phone, pull-up malfunctions before reaching the bottom side of the web page, because the page was magnified.
