### PR TITLE
Adding subheader support for last updated times

### DIFF
--- a/library/res/layout/pull_to_refresh_header.xml
+++ b/library/res/layout/pull_to_refresh_header.xml
@@ -5,15 +5,32 @@
     android:paddingTop="10dp"
     android:paddingBottom="10dip">
     
-     <TextView
-        android:id="@+id/pull_to_refresh_text"
-        android:text="@string/pull_to_refresh_pull_label"
-        android:textAppearance="?android:attr/textAppearanceMedium"
-        android:textStyle="bold"
+	<LinearLayout 
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_centerInParent="true" />
-
+        android:layout_centerInParent="true"
+        android:orientation="vertical"
+        android:gravity="center">
+        
+		<TextView
+	        android:id="@+id/pull_to_refresh_text"
+	        android:text="@string/pull_to_refresh_pull_label"
+	        android:textAppearance="?android:attr/textAppearanceMedium"
+	        android:textStyle="bold"
+	        android:layout_width="wrap_content"
+	        android:layout_height="wrap_content"
+	        android:layout_centerInParent="true" />
+		
+		<TextView
+            android:id="@+id/pull_to_refresh_sub_text"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textAppearance="?android:attr/textAppearanceMedium"
+            android:textSize="11sp"
+            android:visibility="gone" />
+		
+	</LinearLayout>
+	
     <ProgressBar
         android:id="@+id/pull_to_refresh_progress"
         android:indeterminate="true"
@@ -32,7 +49,5 @@
         android:layout_marginLeft="30dip"
         android:layout_marginRight="20dip"
         android:layout_centerVertical="true" />
-
-   
 
 </RelativeLayout>

--- a/library/src/com/handmark/pulltorefresh/library/PullToRefreshBase.java
+++ b/library/src/com/handmark/pulltorefresh/library/PullToRefreshBase.java
@@ -855,4 +855,8 @@ public abstract class PullToRefreshBase<T extends View> extends LinearLayout {
 	public void setLongClickable(boolean longClickable) {
 		getRefreshableView().setLongClickable(longClickable);
 	}
+	
+	public void setSubHeaderText(CharSequence text) {
+		mHeaderLayout.setSubHeaderText(text);
+	}
 }

--- a/library/src/com/handmark/pulltorefresh/library/PullToRefreshBase.java
+++ b/library/src/com/handmark/pulltorefresh/library/PullToRefreshBase.java
@@ -856,7 +856,7 @@ public abstract class PullToRefreshBase<T extends View> extends LinearLayout {
 		getRefreshableView().setLongClickable(longClickable);
 	}
 	
-	public void setSubHeaderText(CharSequence text) {
+	public void setSubHeaderText(String text) {
 		mHeaderLayout.setSubHeaderText(text);
 	}
 }

--- a/library/src/com/handmark/pulltorefresh/library/internal/LoadingLayout.java
+++ b/library/src/com/handmark/pulltorefresh/library/internal/LoadingLayout.java
@@ -3,6 +3,7 @@ package com.handmark.pulltorefresh.library.internal;
 import android.content.Context;
 import android.content.res.TypedArray;
 import android.graphics.Color;
+import android.text.Html;
 import android.text.TextUtils;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -77,7 +78,7 @@ public class LoadingLayout extends FrameLayout {
 	}
 
 	public void reset() {
-		mHeaderText.setText(mPullLabel);
+		mHeaderText.setText(Html.fromHtml(mPullLabel));
 		mHeaderImage.setVisibility(View.VISIBLE);
 		mHeaderProgress.setVisibility(View.GONE);
 		if (TextUtils.isEmpty(mSubHeaderText.getText())) {
@@ -88,7 +89,7 @@ public class LoadingLayout extends FrameLayout {
 	}
 
 	public void releaseToRefresh() {
-		mHeaderText.setText(mReleaseLabel);
+		mHeaderText.setText(Html.fromHtml(mReleaseLabel));
 		mHeaderImage.clearAnimation();
 		mHeaderImage.startAnimation(mRotateAnimation);
 	}
@@ -98,7 +99,7 @@ public class LoadingLayout extends FrameLayout {
 	}
 
 	public void refreshing() {
-		mHeaderText.setText(mRefreshingLabel);
+		mHeaderText.setText(Html.fromHtml(mRefreshingLabel));
 		mHeaderImage.clearAnimation();
 		mHeaderImage.setVisibility(View.INVISIBLE);
 		mHeaderProgress.setVisibility(View.VISIBLE);
@@ -114,7 +115,7 @@ public class LoadingLayout extends FrameLayout {
 	}
 
 	public void pullToRefresh() {
-		mHeaderText.setText(mPullLabel);
+		mHeaderText.setText(Html.fromHtml(mPullLabel));
 		mHeaderImage.clearAnimation();
 		mHeaderImage.startAnimation(mResetRotateAnimation);
 	}
@@ -124,8 +125,8 @@ public class LoadingLayout extends FrameLayout {
 		mSubHeaderText.setTextColor(color);
 	}
 	
-	public void setSubHeaderText(CharSequence text) {
-		mSubHeaderText.setText(text);
+	public void setSubHeaderText(String text) {
+		mSubHeaderText.setText(Html.fromHtml(text));
 		if (TextUtils.isEmpty(text)) {
 			mSubHeaderText.setVisibility(View.GONE);
 		} else {

--- a/library/src/com/handmark/pulltorefresh/library/internal/LoadingLayout.java
+++ b/library/src/com/handmark/pulltorefresh/library/internal/LoadingLayout.java
@@ -3,6 +3,7 @@ package com.handmark.pulltorefresh.library.internal;
 import android.content.Context;
 import android.content.res.TypedArray;
 import android.graphics.Color;
+import android.text.TextUtils;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -25,6 +26,7 @@ public class LoadingLayout extends FrameLayout {
 	private final ImageView mHeaderImage;
 	private final ProgressBar mHeaderProgress;
 	private final TextView mHeaderText;
+	private final TextView mSubHeaderText;
 
 	private String mPullLabel;
 	private String mRefreshingLabel;
@@ -37,6 +39,7 @@ public class LoadingLayout extends FrameLayout {
 		super(context);
 		ViewGroup header = (ViewGroup) LayoutInflater.from(context).inflate(R.layout.pull_to_refresh_header, this);
 		mHeaderText = (TextView) header.findViewById(R.id.pull_to_refresh_text);
+		mSubHeaderText = (TextView) header.findViewById(R.id.pull_to_refresh_sub_text);
 		mHeaderImage = (ImageView) header.findViewById(R.id.pull_to_refresh_image);
 		mHeaderProgress = (ProgressBar) header.findViewById(R.id.pull_to_refresh_progress);
 
@@ -77,6 +80,11 @@ public class LoadingLayout extends FrameLayout {
 		mHeaderText.setText(mPullLabel);
 		mHeaderImage.setVisibility(View.VISIBLE);
 		mHeaderProgress.setVisibility(View.GONE);
+		if (TextUtils.isEmpty(mSubHeaderText.getText())) {
+			mSubHeaderText.setVisibility(View.GONE);
+		} else {
+			mSubHeaderText.setVisibility(View.VISIBLE);
+		}
 	}
 
 	public void releaseToRefresh() {
@@ -94,6 +102,7 @@ public class LoadingLayout extends FrameLayout {
 		mHeaderImage.clearAnimation();
 		mHeaderImage.setVisibility(View.INVISIBLE);
 		mHeaderProgress.setVisibility(View.VISIBLE);
+		mSubHeaderText.setVisibility(View.GONE);
 	}
 
 	public void setRefreshingLabel(String refreshingLabel) {
@@ -112,6 +121,15 @@ public class LoadingLayout extends FrameLayout {
 
 	public void setTextColor(int color) {
 		mHeaderText.setTextColor(color);
+		mSubHeaderText.setTextColor(color);
 	}
-
+	
+	public void setSubHeaderText(CharSequence text) {
+		mSubHeaderText.setText(text);
+		if (TextUtils.isEmpty(text)) {
+			mSubHeaderText.setVisibility(View.GONE);
+		} else {
+			mSubHeaderText.setVisibility(View.VISIBLE);
+		}
+	}
 }


### PR DESCRIPTION
This was originally made to have the ability to show the last updated time underneath the the pull to refresh label.  I decided to just make it a generic string for this pull request so the app can deal with formatting the date (or displaying something else).  Here's the date code I was using just in case it would be preferable to restrict the user to a date:

```
 public void setUpdateTime(Date date) {
    if (date == null) {
        headerUpdateText.setVisibility(View.GONE);
    } else {
        headerUpdateText.setVisibility(View.VISIBLE);
        SimpleDateFormat df;
        Calendar currentCal = Calendar.getInstance();
        Calendar cal = Calendar.getInstance();
        cal.setTime(date);
        if (cal.get(Calendar.YEAR) == currentCal.get(Calendar.YEAR) 
                && cal.get(Calendar.DAY_OF_YEAR) == currentCal.get(Calendar.DAY_OF_YEAR)) {
            df = new SimpleDateFormat("'<b>LAST UPDATED</b> TODAY AT' hh:mm a");
        } else {
            df = new SimpleDateFormat("'<b>LAST UPDATED</b>' M/d/yy 'AT' hh:mm a");
        }

        headerUpdateText.setText(Html.fromHtml(df.format(date)));
    }
} 
```

I also changed all the `TextView.setText(String s)` calls in the LoadingLayout to call `Html.fromHtml(String s)` on the text passed.  This will allow part of the string to be bold, italic, etc.

Both of these additions should have no different effect if they are not used, it should behave as normal.
