### PR TITLE
Last-Updated label in footer and Last-Updated text color

### DIFF
--- a/library/pom.xml
+++ b/library/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>com.github.handmark.pulltorefresh</groupId>
 		<artifactId>pulltorefresh-project</artifactId>
-		<version>1.0</version>
+		<version>2.7.1-SNAPSHOT</version>
 	</parent>
 	<groupId>com.github.handmark.pulltorefresh</groupId>
 	<artifactId>pulltorefresh-library</artifactId>

--- a/library/res/values/attrs.xml
+++ b/library/res/values/attrs.xml
@@ -5,6 +5,7 @@
         <attr name="ptrAdapterViewBackground" format="reference|color" />
         <attr name="ptrHeaderBackground" format="reference|color" />
         <attr name="ptrHeaderTextColor" format="reference|color" />
+        <attr name="ptrHeaderSubTextColor" format="reference|color" />
         <attr name="ptrMode">
             <flag name="pullDownFromTop" value="0x1" />
             <flag name="pullUpFromBottom" value="0x2" />

--- a/library/src/com/handmark/pulltorefresh/library/PullToRefreshBase.java
+++ b/library/src/com/handmark/pulltorefresh/library/PullToRefreshBase.java
@@ -417,7 +417,12 @@ public abstract class PullToRefreshBase<T extends View> extends LinearLayout {
 	 *            - Label to set
 	 */
 	public void setLastUpdatedLabel(CharSequence label) {
-		mHeaderLayout.setSubHeaderText(label);
+		if (null != mHeaderLayout) {
+			mHeaderLayout.setSubHeaderText(label);
+		}
+		if (null != mFooterLayout) {
+			mFooterLayout.setSubHeaderText(label);
+		}
 	}
 
 	public final boolean hasPullFromTop() {

--- a/library/src/com/handmark/pulltorefresh/library/internal/LoadingLayout.java
+++ b/library/src/com/handmark/pulltorefresh/library/internal/LoadingLayout.java
@@ -80,6 +80,10 @@ public class LoadingLayout extends FrameLayout {
 			ColorStateList colors = attrs.getColorStateList(R.styleable.PullToRefresh_ptrHeaderTextColor);
 			setTextColor(null != colors ? colors : ColorStateList.valueOf(0xFF000000));
 		}
+		if (attrs.hasValue(R.styleable.PullToRefresh_ptrHeaderSubTextColor)) {
+			ColorStateList colors = attrs.getColorStateList(R.styleable.PullToRefresh_ptrHeaderSubTextColor);
+			setSubTextColor(null != colors ? colors : ColorStateList.valueOf(0xFF000000));
+		}
 
 		reset();
 	}
@@ -132,8 +136,16 @@ public class LoadingLayout extends FrameLayout {
 		mSubHeaderText.setTextColor(color);
 	}
 
+	public void setSubTextColor(ColorStateList color) {
+		mSubHeaderText.setTextColor(color);
+	}
+
 	public void setTextColor(int color) {
 		setTextColor(ColorStateList.valueOf(color));
+	}
+
+	public void setSubTextColor(int color) {
+		setSubTextColor(ColorStateList.valueOf(color));
 	}
 
 	public void setSubHeaderText(CharSequence label) {

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.github.handmark.pulltorefresh</groupId>
   <artifactId>pulltorefresh-project</artifactId>
-  <version>1.0</version>
+  <version>2.7.1-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Android-PullToRefresh Project</name>
 

--- a/sample/pom.xml
+++ b/sample/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>com.github.handmark.pulltorefresh</groupId>
 		<artifactId>pulltorefresh-project</artifactId>
-		<version>1.0</version>
+		<version>2.7.1-SNAPSHOT</version>
 	</parent>
 	<groupId>com.github.handmark.pulltorefresh</groupId>
 	<artifactId>pulltorefresh-sample</artifactId>


### PR DESCRIPTION
Hi Chris!

This pull request contains the following:
- Last-updated is now shown in the footer as well
- A separate text color can now be set on the last-update label
- Proper Maven versioning has been applied

Regarding Maven versioning, I strongly suggest that you update the version in the POMs after each release you make! I've set it to 2.7.1-SNAPSHOT in this pull request. This version should be updated on each (public) release of the project. Since the last release was 2.7.0, it used 2.7.1 here. SNAPSHOT means that it's a ongoing version (read more about SNAPSHOT versions in chapter 3.5 of "Better Builds with Maven" - http://www.maestrodev.com/wp-content/uploads/2012/03/betterbuildswithmaven-2008.pdf. Notice that you don't have to use 2.7.0, you could for example go for 2.8.0 as well! If you don't start to use/update the Maven version, then I would probably not be able to use your excellent pull-to-refresh lib in my app. I need to be able to know which version (i.e. which code) that I am dependent on. If every release has version 1.0, then there is no way of knowing this (in Maven). Thanks for considering this request!

I saw that you had pushed a fix for automatically scrolling to the end of the list after a refresh at the footer. I specifically do not want to do that! Would it be possible for you to add a boolean flag for this feature (making it optional)!? Thanks!

Best Regards,
Jacob
