### PR TITLE
POM Descriptor is out of sync with tagged semantic version.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.github.handmark.pulltorefresh</groupId>
   <artifactId>pulltorefresh-project</artifactId>
-  <version>1.0</version>
+  <version>1.2.7</version>
   <packaging>pom</packaging>
   <name>Android-PullToRefresh Project</name>
 


### PR DESCRIPTION
I've updated the POM version attribute to the currently tagged 1.2.7. This should help, minutely, in the resolution of issue # [61](https://github.com/chrisbanes/Android-PullToRefresh/issues/61)
