### PR TITLE
fix maven build error

### DIFF
--- a/library/pom.xml
+++ b/library/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>com.github.handmark.pulltorefresh</groupId>
 		<artifactId>pulltorefresh-project</artifactId>
-		<version>2.7.1-SNAPSHOT</version>
+		<version>1.2.8</version>
 	</parent>
 	<groupId>com.github.handmark.pulltorefresh</groupId>
 	<artifactId>pulltorefresh-library</artifactId>


### PR DESCRIPTION
There is an error when build with maven command:
mvn clean install

[ERROR]     Non-resolvable parent POM: Could not find artifact com.github.handmark.pulltorefresh:pulltorefresh-project:pom:2.7.1-SNAPSHOT and 'parent.relativePath' points at wrong local POM @ line 6, column 10 -> [Help 2]
