### PR TITLE
PullToRefreshListView additional header/footer views

### DIFF
--- a/library/src/com/handmark/pulltorefresh/library/PullToRefreshListView.java
+++ b/library/src/com/handmark/pulltorefresh/library/PullToRefreshListView.java
@@ -275,11 +275,11 @@ public class PullToRefreshListView extends PullToRefreshAdapterViewBase<ListView
 	}
 
 	protected int getNumberInternalHeaderViews() {
-		return null != mHeaderLoadingView ? 1 : 0;
+		return null != mRefreshableView ? mRefreshableView.getHeaderViewsCount() : 0;
 	}
 
 	protected int getNumberInternalFooterViews() {
-		return null != mFooterLoadingView ? 1 : 0;
+		return null != mRefreshableView ? mRefreshableView.getFooterViewsCount() : 0;
 	}
 
 }


### PR DESCRIPTION
This fixes the issue #79 I reported earlier.

Currently pull-to-refresh stops working when the ListView is empty and there are additional header/footer views added to it. This changes the number of internal header/footer views to return the actual number from the underlying ListView itself.
