### PR TITLE
pom tweaks for publishing to Maven Central for issue #61

### DIFF
--- a/library/pom.xml
+++ b/library/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>com.github.handmark.pulltorefresh</groupId>
 		<artifactId>pulltorefresh-project</artifactId>
-		<version>1.3.0</version>
+		<version>1.3.0-SNAPSHOT</version>
 	</parent>
 	<groupId>com.github.handmark.pulltorefresh</groupId>
 	<artifactId>pulltorefresh-library</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,8 +6,34 @@
   <groupId>com.github.handmark.pulltorefresh</groupId>
   <artifactId>pulltorefresh-project</artifactId>
   <version>1.3.0</version>
+  <parent>
+    <groupId>org.sonatype.oss</groupId>
+    <artifactId>oss-parent</artifactId>
+    <version>7</version>
+  </parent>
   <packaging>pom</packaging>
   <name>Android-PullToRefresh Project</name>
+  <description>Implementation of the Pull-to-Refresh UI Pattern for Android.</description>
+  <url>https://github.com/chrisbanes/Android-PullToRefresh</url>
+  <licenses>
+    <license>
+      <name>Apache V2</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+  <scm>
+    <url>https://github.com/chrisbanes/Android-PullToRefresh</url>
+    <connection>scm:git:git://github.com/chrisbanes/Android-PullToRefresh.git</connection>
+    <developerConnection>scm:git:git@github.com:chrisbanes/Android-PullToRefresh.git</developerConnection>
+  </scm>
+  <developers>
+    <developer>
+      <name>Chris Banes</name>
+      <url>http://about.me/chrisbanes</url>
+      <id>chrisbanes</id>
+    </developer>
+  </developers>
 
   <modules>
     <module>library</module>

--- a/pom.xml
+++ b/pom.xml
@@ -47,15 +47,11 @@
 		      <plugin>
 		        <groupId>com.jayway.maven.plugins.android.generation2</groupId>
 		        <artifactId>android-maven-plugin</artifactId>
-		        <version>3.0.0</version>
+		        <version>3.2.0</version>
 				<configuration>
             <sdk>
               <platform>${androidApiLevel}</platform>
             </sdk>
-            <dexJvmArguments>
-              <jvmArgument>-Xms256m</jvmArgument>
-              <jvmArgument>-Xmx512m</jvmArgument>
-            </dexJvmArguments>
             <undeployBeforeDeploy>true</undeployBeforeDeploy>
 			<source>${sourceCompatibility}</source>
 	          <target>${sourceCompatibility}</target>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.github.handmark.pulltorefresh</groupId>
   <artifactId>pulltorefresh-project</artifactId>
-  <version>1.3.0</version>
+  <version>1.3.0-SNAPSHOT</version>
   <parent>
     <groupId>org.sonatype.oss</groupId>
     <artifactId>oss-parent</artifactId>

--- a/sample/pom.xml
+++ b/sample/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>com.github.handmark.pulltorefresh</groupId>
 		<artifactId>pulltorefresh-project</artifactId>
-		<version>1.3.0</version>
+		<version>1.3.0-SNAPSHOT</version>
 	</parent>
 	<groupId>com.github.handmark.pulltorefresh</groupId>
 	<artifactId>pulltorefresh-sample</artifactId>


### PR DESCRIPTION
These tweaks fulfil the remaining requirements to get the Android-PullToRefresh artifact released to Maven Central - these are the remaining steps from the [Sonatype OSS Maven Repository Usage Guide](https://docs.sonatype.org/display/Repository/Sonatype+OSS+Maven+Repository+Usage+Guide) in order to complete a release to Maven Central:

```
2. Sign up to https://issues.sonatype.org/
3. Create a JIRA ticket
7a. Deploy Snapshots and Stage Releases with Maven
8. Release It
9. Activate Central Sync
```

This pull-request is based off master (though I understand you generally prefer commits to come in on the dev branch) as it's preferable to make releases to Maven Central that are based of the stable branch.

As a temporary measure, I've released a copy of Android-PullToRefresh to Maven Central (obviously, it would be better in the long term if you as project maintainer were responsible for Maven releases, rather than me lobbing out unofficial releases!):

http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22com.madgag%22%20a%3A%22pulltorefresh-library%22
