### PR TITLE
Directly get index of ListView in PullToRefreshListFragment instead of iterating through child views

### DIFF
--- a/extras/PullToRefreshListFragment/src/com/handmark/pulltorefresh/extras/listfragment/PullToRefreshListFragment.java
+++ b/extras/PullToRefreshListFragment/src/com/handmark/pulltorefresh/extras/listfragment/PullToRefreshListFragment.java
@@ -2,12 +2,10 @@ package com.handmark.pulltorefresh.extras.listfragment;
 
 import android.os.Bundle;
 import android.support.v4.app.ListFragment;
-import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ListView;
-
 import com.handmark.pulltorefresh.library.PullToRefreshListView;
 
 /**

--- a/extras/PullToRefreshListFragment/src/com/handmark/pulltorefresh/extras/listfragment/PullToRefreshListFragment.java
+++ b/extras/PullToRefreshListFragment/src/com/handmark/pulltorefresh/extras/listfragment/PullToRefreshListFragment.java
@@ -2,6 +2,7 @@ package com.handmark.pulltorefresh.extras.listfragment;
 
 import android.os.Bundle;
 import android.support.v4.app.ListFragment;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -34,21 +35,11 @@ public class PullToRefreshListFragment extends ListFragment {
 		ListView lv = (ListView) layout.findViewById(android.R.id.list);
 		ViewGroup parent = (ViewGroup) lv.getParent();
 
-		// Iterate through parent's children until we find the ListView, we need
-		// to do it this way as we need to find out the child index
-		for (int i = 0, z = parent.getChildCount(); i < z; i++) {
-			View child = parent.getChildAt(i);
-
-			if (child == lv) {
-				// Remove the ListView first
-				parent.removeViewAt(i);
-
-				// Now create ListView, and add it in it's place...
-				mPullToRefreshListView = onCreatePullToRefreshListView(inflater, savedInstanceState);
-				parent.addView(mPullToRefreshListView, i, lv.getLayoutParams());
-				break;
-			}
-		}
+        //Remove ListView and add PullToRefreshListView in its place
+        int lvIndex = parent.indexOfChild(lv);
+        parent.removeViewAt(lvIndex);
+        mPullToRefreshListView = onCreatePullToRefreshListView(inflater, savedInstanceState);
+        parent.addView(mPullToRefreshListView, lvIndex, lv.getLayoutParams());
 
 		return layout;
 	}


### PR DESCRIPTION
As per Romain Guy's answer [here](http://stackoverflow.com/questions/3334754/how-to-get-the-index-of-particular-view-or-viewgroup-which-is-added-to-the-viewg)
