### PR TITLE
Use setMode() to restore mode in onRestoreInstanceState()

### DIFF
--- a/library/src/com/handmark/pulltorefresh/library/PullToRefreshBase.java
+++ b/library/src/com/handmark/pulltorefresh/library/PullToRefreshBase.java
@@ -860,7 +860,7 @@ public abstract class PullToRefreshBase<T extends View> extends LinearLayout imp
 		if (state instanceof Bundle) {
 			Bundle bundle = (Bundle) state;
 
-			mMode = Mode.mapIntToValue(bundle.getInt(STATE_MODE, 0));
+			setMode(Mode.mapIntToValue(bundle.getInt(STATE_MODE, 0)));
 			mCurrentMode = Mode.mapIntToValue(bundle.getInt(STATE_CURRENT_MODE, 0));
 
 			mScrollingWhileRefreshingEnabled = bundle.getBoolean(STATE_SCROLLING_REFRESHING_ENABLED, false);


### PR DESCRIPTION
When restoring a mode != DISABLED with the current mode being DISABLED
the header and/or footer layout weren't added to the view. That's why we
now call setMode() instead of setting mMode directly.

I'm not sure this is the most elegant fix for the problem. But it works for me.

![pull_to_refresh_header_layout_present](https://f.cloud.github.com/assets/218061/13088/7c6b90dc-45e0-11e2-923f-6c79df835814.png)

vs.

![pull_to_refresh_header_layout_missing](https://f.cloud.github.com/assets/218061/13089/8f89c77e-45e0-11e2-8ae9-83861970d4f3.png)
