### PR TITLE
Add a generic logger interface that mimics android.util.Log so another o...

### DIFF
--- a/library/src/com/handmark/pulltorefresh/library/LogManager.java
+++ b/library/src/com/handmark/pulltorefresh/library/LogManager.java
@@ -1,0 +1,17 @@
+package com.handmark.pulltorefresh.library;
+
+/**
+ * class that holds the {@link Logger} for this library
+ */
+public final class LogManager {
+
+	static Logger logger = new LoggerDefault();
+	
+	public static void setLogger(Logger newLogger) {
+		logger = newLogger;
+	}
+	
+	public static Logger getLogger() {
+		return logger;
+	}
+}

--- a/library/src/com/handmark/pulltorefresh/library/Logger.java
+++ b/library/src/com/handmark/pulltorefresh/library/Logger.java
@@ -1,0 +1,91 @@
+package com.handmark.pulltorefresh.library;
+
+/**
+ * interface for a logger class to replace the static calls to {@link android.util.Log}
+ */
+public interface Logger {
+    /**
+     * Send a {@link android.util.Log#VERBOSE} log message.
+     * @param tag Used to identify the source of a log message.  It usually identifies
+     *        the class or activity where the log call occurs.
+     * @param msg The message you would like logged.
+     */
+	int v(String tag, String msg);
+	
+    /**
+     * Send a {@link android.util.Log#VERBOSE} log message and log the exception.
+     * @param tag Used to identify the source of a log message.  It usually identifies
+     *        the class or activity where the log call occurs.
+     * @param msg The message you would like logged.
+     * @param tr An exception to log
+     */
+    int v(String tag, String msg, Throwable tr);
+	
+    /**
+     * Send a {@link android.util.Log#DEBUG} log message.
+     * @param tag Used to identify the source of a log message.  It usually identifies
+     *        the class or activity where the log call occurs.
+     * @param msg The message you would like logged.
+     */
+    int d(String tag, String msg);
+	
+    /**
+     * Send a {@link android.util.Log#DEBUG} log message and log the exception.
+     * @param tag Used to identify the source of a log message.  It usually identifies
+     *        the class or activity where the log call occurs.
+     * @param msg The message you would like logged.
+     * @param tr An exception to log
+     */
+    int d(String tag, String msg, Throwable tr);
+
+    /**
+     * Send an {@link android.util.Log#INFO} log message.
+     * @param tag Used to identify the source of a log message.  It usually identifies
+     *        the class or activity where the log call occurs.
+     * @param msg The message you would like logged.
+     */
+    int i(String tag, String msg);
+	
+    /**
+     * Send a {@link android.util.Log#INFO} log message and log the exception.
+     * @param tag Used to identify the source of a log message.  It usually identifies
+     *        the class or activity where the log call occurs.
+     * @param msg The message you would like logged.
+     * @param tr An exception to log
+     */
+    int i(String tag, String msg, Throwable tr);
+	
+    /**
+     * Send a {@link android.util.Log#WARN} log message.
+     * @param tag Used to identify the source of a log message.  It usually identifies
+     *        the class or activity where the log call occurs.
+     * @param msg The message you would like logged.
+     */
+    int w(String tag, String msg);
+	
+    /**
+     * Send a {@link android.util.Log#WARN} log message and log the exception.
+     * @param tag Used to identify the source of a log message.  It usually identifies
+     *        the class or activity where the log call occurs.
+     * @param msg The message you would like logged.
+     * @param tr An exception to log
+     */
+    int w(String tag, String msg, Throwable tr);
+	
+    /**
+     * Send an {@link android.util.Log#ERROR} log message.
+     * @param tag Used to identify the source of a log message.  It usually identifies
+     *        the class or activity where the log call occurs.
+     * @param msg The message you would like logged.
+     */
+    int e(String tag, String msg);
+	
+    /**
+     * Send a {@link android.util.Log#ERROR} log message and log the exception.
+     * @param tag Used to identify the source of a log message.  It usually identifies
+     *        the class or activity where the log call occurs.
+     * @param msg The message you would like logged.
+     * @param tr An exception to log
+     */
+    int e(String tag, String msg, Throwable tr);
+}

--- a/library/src/com/handmark/pulltorefresh/library/LoggerDefault.java
+++ b/library/src/com/handmark/pulltorefresh/library/LoggerDefault.java
@@ -1,0 +1,60 @@
+package com.handmark.pulltorefresh.library;
+
+import android.util.Log;
+
+/**
+ * Helper class to redirect {@link LogManager#logger} to {@link android.util.Log}
+ */
+public class LoggerDefault implements Logger {
+
+	@Override
+	public int v(String tag, String msg) {
+		return Log.v(tag, msg);
+	}
+
+	@Override
+	public int v(String tag, String msg, Throwable tr) {
+		return Log.v(tag, msg, tr);
+	}
+
+	@Override
+	public int d(String tag, String msg) {
+		return Log.d(tag, msg);
+	}
+
+	@Override
+	public int d(String tag, String msg, Throwable tr) {
+		return Log.d(tag, msg, tr);
+	}
+
+	@Override
+	public int i(String tag, String msg) {
+		return Log.i(tag, msg);
+	}
+
+	@Override
+	public int i(String tag, String msg, Throwable tr) {
+		return Log.i(tag, msg, tr);
+	}
+
+	@Override
+	public int w(String tag, String msg) {
+		return Log.w(tag, msg);
+	}
+
+	@Override
+	public int w(String tag, String msg, Throwable tr) {
+		return Log.w(tag, msg, tr);
+	}
+
+	@Override
+	public int e(String tag, String msg) {
+		return Log.e(tag, msg);
+	}
+
+	@Override
+	public int e(String tag, String msg, Throwable tr) {
+		return Log.e(tag, msg, tr);
+	}
+
+}

--- a/library/src/com/handmark/pulltorefresh/library/OverscrollHelper.java
+++ b/library/src/com/handmark/pulltorefresh/library/OverscrollHelper.java
@@ -129,7 +129,7 @@ public final class OverscrollHelper {
 				final int newScrollValue = (deltaValue + scrollValue);
 
 				if (PullToRefreshBase.DEBUG) {
-					Log.d(LOG_TAG, "OverScroll. DeltaX: " + deltaX + ", ScrollX: " + scrollX + ", DeltaY: " + deltaY
+					LogManager.logger.d(LOG_TAG, "OverScroll. DeltaX: " + deltaX + ", ScrollX: " + scrollX + ", DeltaY: " + deltaY
 							+ ", ScrollY: " + scrollY + ", NewY: " + newScrollValue + ", ScrollRange: " + scrollRange
 							+ ", CurrentScroll: " + currentScrollValue);
 				}

--- a/library/src/com/handmark/pulltorefresh/library/PullToRefreshAdapterViewBase.java
+++ b/library/src/com/handmark/pulltorefresh/library/PullToRefreshAdapterViewBase.java
@@ -103,7 +103,7 @@ public abstract class PullToRefreshAdapterViewBase<T extends AbsListView> extend
 			final int totalItemCount) {
 
 		if (DEBUG) {
-			Log.d(LOG_TAG, "First Visible: " + firstVisibleItem + ". Visible Count: " + visibleItemCount
+			LogManager.logger.d(LOG_TAG, "First Visible: " + firstVisibleItem + ". Visible Count: " + visibleItemCount
 					+ ". Total Items:" + totalItemCount);
 		}
 
@@ -380,7 +380,7 @@ public abstract class PullToRefreshAdapterViewBase<T extends AbsListView> extend
 
 		if (null == adapter || adapter.isEmpty()) {
 			if (DEBUG) {
-				Log.d(LOG_TAG, "isFirstItemVisible. Empty View.");
+				LogManager.logger.d(LOG_TAG, "isFirstItemVisible. Empty View.");
 			}
 			return true;
 

--- a/library/src/com/handmark/pulltorefresh/library/PullToRefreshBase.java
+++ b/library/src/com/handmark/pulltorefresh/library/PullToRefreshBase.java
@@ -129,7 +129,7 @@ public abstract class PullToRefreshBase<T extends View> extends LinearLayout imp
 	@Override
 	public void addView(View child, int index, ViewGroup.LayoutParams params) {
 		if (DEBUG) {
-			Log.d(LOG_TAG, "addView: " + child.getClass().getSimpleName());
+			LogManager.logger.d(LOG_TAG, "addView: " + child.getClass().getSimpleName());
 		}
 
 		final T refreshableView = getRefreshableView();
@@ -434,7 +434,7 @@ public abstract class PullToRefreshBase<T extends View> extends LinearLayout imp
 	public final void setMode(Mode mode) {
 		if (mode != mMode) {
 			if (DEBUG) {
-				Log.d(LOG_TAG, "Setting mode to: " + mode);
+				LogManager.logger.d(LOG_TAG, "Setting mode to: " + mode);
 			}
 			mMode = mode;
 			updateUIForMode();
@@ -551,7 +551,7 @@ public abstract class PullToRefreshBase<T extends View> extends LinearLayout imp
 	final void setState(State state, final boolean... params) {
 		mState = state;
 		if (DEBUG) {
-			Log.d(LOG_TAG, "State: " + mState.name());
+			LogManager.logger.d(LOG_TAG, "State: " + mState.name());
 		}
 
 		switch (mState) {
@@ -843,7 +843,7 @@ public abstract class PullToRefreshBase<T extends View> extends LinearLayout imp
 	@Override
 	protected final void onSizeChanged(int w, int h, int oldw, int oldh) {
 		if (DEBUG) {
-			Log.d(LOG_TAG, String.format("onSizeChanged. W: %d, H: %d", w, h));
+			LogManager.logger.d(LOG_TAG, String.format("onSizeChanged. W: %d, H: %d", w, h));
 		}
 
 		super.onSizeChanged(w, h, oldw, oldh);
@@ -913,7 +913,7 @@ public abstract class PullToRefreshBase<T extends View> extends LinearLayout imp
 		}
 
 		if (DEBUG) {
-			Log.d(LOG_TAG, String.format("Setting Padding. L: %d, T: %d, R: %d, B: %d", pLeft, pTop, pRight, pBottom));
+			LogManager.logger.d(LOG_TAG, String.format("Setting Padding. L: %d, T: %d, R: %d, B: %d", pLeft, pTop, pRight, pBottom));
 		}
 		setPadding(pLeft, pTop, pRight, pBottom);
 	}
@@ -947,7 +947,7 @@ public abstract class PullToRefreshBase<T extends View> extends LinearLayout imp
 	 */
 	protected final void setHeaderScroll(final int value) {
 		if (DEBUG) {
-			Log.d(LOG_TAG, "setHeaderScroll: " + value);
+			LogManager.logger.d(LOG_TAG, "setHeaderScroll: " + value);
 		}
 
 		if (mLayoutVisibilityChangesEnabled) {

--- a/library/src/com/handmark/pulltorefresh/library/internal/Utils.java
+++ b/library/src/com/handmark/pulltorefresh/library/internal/Utils.java
@@ -1,13 +1,13 @@
 package com.handmark.pulltorefresh.library.internal;
 
-import android.util.Log;
+import com.handmark.pulltorefresh.library.LogManager;
 
 public class Utils {
 
 	static final String LOG_TAG = "PullToRefresh";
 
 	public static void warnDeprecation(String depreacted, String replacement) {
-		Log.w(LOG_TAG, "You're using the deprecated " + depreacted + " attr, please switch over to " + replacement);
+		LogManager.getLogger().w(LOG_TAG, "You're using the deprecated " + depreacted + " attr, please switch over to " + replacement);
 	}
 
 }


### PR DESCRIPTION
I am working on a generic API for android libraries so it's easier for the lib user to redirect the logs to something else. It's transparent if you don't call LogManager.setLogger()
