### PR TITLE
Added setBackground for ILoadingLayout to set background for loader

### DIFF
--- a/library/src/com/handmark/pulltorefresh/library/ILoadingLayout.java
+++ b/library/src/com/handmark/pulltorefresh/library/ILoadingLayout.java
@@ -8,7 +8,7 @@ public interface ILoadingLayout {
 	/**
 	 * Set the Last Updated Text. This displayed under the main label when
 	 * Pulling
-	 * 
+	 *
 	 * @param label - Label to set
 	 */
 	public void setLastUpdatedLabel(CharSequence label);
@@ -16,7 +16,7 @@ public interface ILoadingLayout {
 	/**
 	 * Set the drawable used in the loading layout. This is the same as calling
 	 * <code>setLoadingDrawable(drawable, Mode.BOTH)</code>
-	 * 
+	 *
 	 * @param drawable - Drawable to display
 	 */
 	public void setLoadingDrawable(Drawable drawable);
@@ -24,7 +24,7 @@ public interface ILoadingLayout {
 	/**
 	 * Set Text to show when the Widget is being Pulled
 	 * <code>setPullLabel(releaseLabel, Mode.BOTH)</code>
-	 * 
+	 *
 	 * @param pullLabel - CharSequence to display
 	 */
 	public void setPullLabel(CharSequence pullLabel);
@@ -32,7 +32,7 @@ public interface ILoadingLayout {
 	/**
 	 * Set Text to show when the Widget is refreshing
 	 * <code>setRefreshingLabel(releaseLabel, Mode.BOTH)</code>
-	 * 
+	 *
 	 * @param refreshingLabel - CharSequence to display
 	 */
 	public void setRefreshingLabel(CharSequence refreshingLabel);
@@ -41,17 +41,25 @@ public interface ILoadingLayout {
 	 * Set Text to show when the Widget is being pulled, and will refresh when
 	 * released. This is the same as calling
 	 * <code>setReleaseLabel(releaseLabel, Mode.BOTH)</code>
-	 * 
+	 *
 	 * @param releaseLabel - CharSequence to display
 	 */
 	public void setReleaseLabel(CharSequence releaseLabel);
 
 	/**
-	 * Set's the Sets the typeface and style in which the text should be
+	 * Sets the typeface and style in which the text should be
 	 * displayed. Please see
 	 * {@link android.widget.TextView#setTypeface(Typeface)
 	 * TextView#setTypeface(Typeface)}.
 	 */
 	public void setTextTypeface(Typeface tf);
+
+	/**
+	 * Sets the background for the LoadingLayout. Please see
+	 * {@link android.view.View#setBackground(android.graphics.drawable.Drawable)}
+	 *
+	 * @param drawable - Drawable to use as background
+	 */
+	public void setBackground(Drawable drawable);
 
 }

--- a/library/src/com/handmark/pulltorefresh/library/LoadingLayoutProxy.java
+++ b/library/src/com/handmark/pulltorefresh/library/LoadingLayoutProxy.java
@@ -1,11 +1,10 @@
 package com.handmark.pulltorefresh.library;
 
-import java.util.HashSet;
-
 import android.graphics.Typeface;
 import android.graphics.drawable.Drawable;
-
 import com.handmark.pulltorefresh.library.internal.LoadingLayout;
+
+import java.util.HashSet;
 
 public class LoadingLayoutProxy implements ILoadingLayout {
 
@@ -21,7 +20,7 @@ public class LoadingLayoutProxy implements ILoadingLayout {
 	 * included in any
 	 * {@link PullToRefreshBase#createLoadingLayoutProxy(boolean, boolean)
 	 * createLoadingLayoutProxy(...)} calls.
-	 * 
+	 *
 	 * @param layout - LoadingLayout to have included.
 	 */
 	public void addLayout(LoadingLayout layout) {
@@ -68,6 +67,13 @@ public class LoadingLayoutProxy implements ILoadingLayout {
 	public void setTextTypeface(Typeface tf) {
 		for (LoadingLayout layout : mLoadingLayouts) {
 			layout.setTextTypeface(tf);
+		}
+	}
+
+	@Override
+	public void setBackground(Drawable drawable) {
+		for (LoadingLayout layout : mLoadingLayouts) {
+			layout.setBackground(drawable);
 		}
 	}
 }


### PR DESCRIPTION
_Please be gentle - it's my first pull request and odds are that I'm not following protocol to 100%_

I wanted the LoadingLayout to be more visually distinct so I added setBackground(Drawable) so that the background of the LoadingLayout can be changed:

![image](https://f.cloud.github.com/assets/2177761/114395/1af8ee12-6b9c-11e2-8d52-aeb058556e20.png)

There is one issue with this code: the background fills the entire space below the list (in my case) but only for the first refresh. Subsequent refreshes shows the LoadingLayout pretty much as `wrap_content` and I couldn't find a way to fix this. I'm _assuming_ that that's a general bug that just wasn't visible before setting a contrasting background:

![image](https://f.cloud.github.com/assets/2177761/114416/6da800de-6b9d-11e2-97e1-a0893996ac72.png)
