### PR TITLE
Update PullToRefreshAdapterViewBase.java

### DIFF
--- a/library/src/com/handmark/pulltorefresh/library/PullToRefreshAdapterViewBase.java
+++ b/library/src/com/handmark/pulltorefresh/library/PullToRefreshAdapterViewBase.java
@@ -423,7 +423,7 @@ public abstract class PullToRefreshAdapterViewBase<T extends AbsListView> extend
 			 * account for it and rely on the inner condition which checks
 			 * getBottom().
 			 */
-			if (lastVisiblePosition >= lastItemPosition - 1) {
+			if (lastVisiblePosition >= lastItemPosition) {
 				final int childIndex = lastVisiblePosition - mRefreshableView.getFirstVisiblePosition();
 				final View lastVisibleChild = mRefreshableView.getChildAt(childIndex);
 				if (lastVisibleChild != null) {


### PR DESCRIPTION
when i use PullToRefreshGridView ,
I have 10 items ,
every row display 3 items ,
screen just display 3 rows,
the last items can not display anyway ,
I modify this , it works .

当我用PullToRefreshGridView时，
我有10个item，
每一行显示3个item，
屏幕上显示了三行刚好把屏幕占满，
无论怎么拖动最后一个item总是显示不出来，
我修改成这样就好了。

before:
![20141222172148](https://cloud.githubusercontent.com/assets/3378432/5523141/992630e6-89ff-11e4-8f95-4f8ede7d789f.jpeg)

after:
![20141222171941](https://cloud.githubusercontent.com/assets/3378432/5523145/a3428840-89ff-11e4-840c-21a9d4ed6f72.jpeg)
