### PR TITLE
Added minimal support for Gradle, for compiling as gradle module in android studio project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 bin
 gen
 
+/*/build/
+
 #Eclipse
 .project
 .classpath

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -1,0 +1,55 @@
+apply plugin: 'com.android.library'
+
+android {
+    compileSdkVersion 16
+    buildToolsVersion '19.1.0'
+
+    defaultConfig {
+        minSdkVersion 4
+        targetSdkVersion 4
+    }
+
+    sourceSets {
+        main {
+            manifest {
+                srcFile 'AndroidManifest.xml'
+            }
+            java {
+                srcDir 'src'
+            }
+            res {
+                srcDir 'res'
+            }
+            assets {
+                srcDir 'assets'
+            }
+            resources {
+                srcDir 'src'
+            }
+        }
+    }
+}
+
+android.libraryVariants.all  { variant ->      
+    def name = variant.buildType.name      
+    if (!name.equals("debug")) {      
+        def task = project.tasks.create  "jar${name.capitalize()}", Jar      
+        task.dependsOn variant.javaCompile      
+        task.from  variant.javaCompile.destinationDir      
+        artifacts.add('archives', task);      
+    }      
+}
+
+
+buildscript {
+    repositories {
+        jcenter()
+    }
+
+}
+
+allprojects {
+    repositories {
+        jcenter()
+    }
+}


### PR DESCRIPTION
added to main project _setting.gradle_

```
include 'ViewPagerIndicator'
project(':ViewPagerIndicator').projectDir = new File('ViewPagerIndicator/library')
```

added in _app/build.gradle_

```
 dependencies {
        compile project (path: ':ViewPagerIndicator')
}
```
